### PR TITLE
Performance improvement in BZAR::smb_admin_file_share_test()

### DIFF
--- a/implementations/bzar/bzar_smb.bro
+++ b/implementations/bzar/bzar_smb.bro
@@ -90,16 +90,14 @@ function smb_admin_file_share_test ( s : SMB::State ) : bool
 	local a = 0;
 	local b = |tree_parts|;
 
-	local match = F;
-
 	while ( a < b )
 	{
 		if ( tree_parts[a] in BZAR::smb_admin_file_shares)
-			match = T;
+			return T;
 		++a;
 	}
 
-	return match;
+	return F;
 }
 
 function smb_full_path_and_file_name ( s : SMB::State ) : string


### PR DESCRIPTION
Hi folks! Great scripts. Just a small performance tweak here: this short-cuts the check of each tree part so the function returns T right away if a part matches one of the admin share definitions, and F if none do. I haven't done performance measurements but I'd imagine for lengthy paths the difference is significant.