### PR TITLE
Update CAR-2016-04-002 to name the correct log

### DIFF
--- a/docs/analytics/CAR-2016-04-002.md
+++ b/docs/analytics/CAR-2016-04-002.md
@@ -17,10 +17,10 @@ It is unlikely that event log data would be cleared during normal operations, an
 |[Indicator Blocking](https://attack.mitre.org/techniques/T1054/)|[Defense Evasion](https://attack.mitre.org/tactics/TA0005)|Moderate|
 
 ## Pseudocode
-When an eventlog is cleared, a new event is created that alerts that the eventlog was cleared. For System logs, its event code 1100 and 1102. For Security logs, it is event code 104. 
+When an eventlog is cleared, a new event is created that alerts that the eventlog was cleared. For Security logs, its event code 1100 and 1102. For System logs, it is event code 104. 
 ```
-([log_name] == "System" and [event_code] in [1100, 1102]) or
-([log_name] == "Security" and [event_code] == 104)
+([log_name] == "Security" and [event_code] in [1100, 1102]) or
+([log_name] == "System" and [event_code] == 104)
 ```
 
 ## Unit Tests


### PR DESCRIPTION
According to actual log sources, and current Microsoft documentation; the log names are mislabeled.

- 104: Unable to find current up-to-date information regarding this event, but our current logs show this is a "System" log
- 1100: https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-1100
- 1102: https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-1102