### PR TITLE
Add tracking of UIDs via sampling

### DIFF
--- a/implementations/bzar/scripts/bzar_dce-rpc.bro
+++ b/implementations/bzar/scripts/bzar_dce-rpc.bro
@@ -266,11 +266,10 @@ event dce_rpc_response(c: connection, fid: count, ctx_id: count, opnum: count, s
 	     c$id$orig_h !in BZAR::ignore_orig_h )
 	{
 		# Looks like DCE-RPC Discovery
-		# Set Observation
-		SumStats::observe("attack_discovery",
-				  SumStats::Key($host=c$id$orig_h),
-				  SumStats::Observation($num=1)
-		);
+		SumStats::observe("attack_discovery", 
+						  [$host=c$id$orig_h], 
+						  [$str=c$uid, 
+						   $num=1]);
 	}
 
 	if ( rpc in BZAR::rpc_execution &&
@@ -285,10 +284,10 @@ event dce_rpc_response(c: connection, fid: count, ctx_id: count, opnum: count, s
 		);
 
 		# Set Observation, Score == 1000 for RPC_EXEC
-		SumStats::observe("attack_lm_ex",
-				  SumStats::Key($host=c$id$resp_h),
-				  SumStats::Observation($num=1000)
-		);
+		SumStats::observe("attack_lm_ex", 
+						  [$host=c$id$resp_h], 
+						  [$str=c$uid, 
+						   $num=1000]);
 	}
 
 	if ( rpc in BZAR::rpc_persistence )

--- a/implementations/bzar/scripts/bzar_smb.bro
+++ b/implementations/bzar/scripts/bzar_smb.bro
@@ -127,11 +127,10 @@ event smb1_tree_connect_andx_request(c: connection, hdr: SMB1::Header, path: str
 	     c$id$orig_h !in BZAR::ignore_orig_h )
 	{
 		# ATT&CK Technique - T1077 Windows Admin Share (File Shares Only)
-		# Set Observation
-		SumStats::observe("attack_t1077",
-		 	  SumStats::Key($host=c$id$orig_h),
-			  SumStats::Observation($num=1)
-		);
+		SumStats::observe("attack_t1077", 
+						  [$host=c$id$orig_h], 
+						  [$str=c$uid, 
+						   $num=1]);
 	}
 }
 
@@ -190,11 +189,11 @@ event smb1_write_andx_response(c: connection, hdr: SMB1::Header, written_bytes: 
 			$conn=c]
 		);
 
-		# Set Observation, Score == 1 for SMB::FILE_WRITE
-		SumStats::observe("attack_lm_ex",
-				  SumStats::Key($host=c$id$resp_h),
-				  SumStats::Observation($num=1)
-		);
+		# Set Observation - Score == 1 for SMB::FILE_WRITE
+		SumStats::observe("attack_lm_ex", 
+						  [$host=c$id$resp_h], 
+						  [$str=c$uid, 
+						   $num=1]);
 	}
 }
 
@@ -240,11 +239,10 @@ event smb2_tree_connect_request(c: connection, hdr: SMB2::Header, path: string) 
 	     c$id$orig_h !in BZAR::ignore_orig_h )
 	{
 		# ATT&CK Technique - T1077 Windows Admin Share (File Shares Only)
-		# Set Observation
-		SumStats::observe("attack_t1077",
-				  SumStats::Key($host=c$id$orig_h),
-				  SumStats::Observation($num=1)
-		);
+		SumStats::observe("attack_t1077", 
+						  [$host=c$id$orig_h], 
+						  [$str=c$uid, 
+						   $num=1]);
 	}
 }
 
@@ -262,6 +260,7 @@ event smb2_create_request(c: connection, hdr: SMB2::Header, request: SMB2::Creat
 {
 
 @endif
+
 	# Copied this snippet from Bro default handler:
 	# policy/protocols/smb/smb1-main.bro#smb1_write_andx_request.
 	# It is important to know the full file path at SMB::FILE_OPEN time,
@@ -309,10 +308,10 @@ event smb2_write_request(c: connection, hdr: SMB2::Header, file_id: SMB2::GUID, 
 		);
 
 		# Set Observation, Score == 1 for SMB::FILE_WRITE
-		SumStats::observe("attack_lm_ex",
-				  SumStats::Key($host=c$id$resp_h),
-				  SumStats::Observation($num=1)
-		);
+		SumStats::observe("attack_lm_ex", 
+						  [$host=c$id$resp_h], 
+						  [$str=c$uid, 
+						   $num=1]);
 	}
 }
 


### PR DESCRIPTION
The changes encompassed here leverage the sumstats sampling, with a redef, to allow all the NOTICEs to report some kind of UID to correlate traffic.