### PR TITLE
Minimal osquery sensor model

### DIFF
--- a/docs/sensors/osquery_4.1.2.yaml
+++ b/docs/sensors/osquery_4.1.2.yaml
@@ -1,0 +1,136 @@
+---
+sensor_name: osquery
+sensor_version: 4.1.2
+sensor_developer: osquery project
+sensor_url: 'https://osquery.io/'
+sensor_description: 'osquery exposes an operating system as a high-performance relational database. This allows you to write SQL-based queries to explore operating system data.'
+mappings:
+  - object: file
+    action: create
+    notes: 'Mapped to the process_file_events, file, and file_events tables.'
+    fields:
+      - creation_time
+      - file_name
+      - file_path
+      - image_path
+      - md5_hash
+      - pid
+      - ppid
+      - sha1_hash
+      - sha256_hash
+      - user
+  - object: file
+    action: delete
+    notes: 'Mapped to the process_file_events, file, and file_events tables.'
+    fields:
+      - creation_time
+      - file_name
+      - file_path
+      - image_path
+      - md5_hash
+      - pid
+      - ppid
+      - sha1_hash
+      - sha256_hash
+      - user
+  - object: file
+    action: modify
+    notes: 'Mapped to the process_file_events, file, and file_events tables.'
+    fields:
+      - creation_time
+      - file_name
+      - file_path
+      - image_path
+      - md5_hash
+      - pid
+      - ppid
+      - sha1_hash
+      - sha256_hash
+      - user
+  - object: file
+    action: timestomp
+    notes: 'Mapped to the process_file_events, file, and file_events tables.'
+    fields:
+      - creation_time
+      - file_name
+      - file_path
+      - image_path
+      - md5_hash
+      - pid
+      - ppid
+      - sha1_hash
+      - sha256_hash
+      - user
+  - object: file
+    action: write
+    notes: 'Mapped to the process_file_events, file, and file_events tables.'
+    fields:
+      - creation_time
+      - file_name
+      - file_path
+      - image_path
+      - md5_hash
+      - pid
+      - ppid
+      - sha1_hash
+      - sha256_hash
+      - user
+  - object: flow
+    action: end
+    notes: 'Mapped to the socket_events table'
+    fields:
+      - dest_ip
+      - dest_port
+      - image_path
+      - pid
+      - protocol
+      - src_ip
+      - src_port
+      - start_time
+      - user
+  - object: flow
+    action: start
+    notes: 'Mapped to the socket_events table'
+    fields:
+      - dest_ip
+      - dest_port
+      - image_path
+      - pid
+      - protocol
+      - src_ip
+      - src_port
+      - start_time
+      - user
+  - object: process
+    action: create
+    notes: 'Mapped to the process_events, file, and hash tables.'
+    fields:
+      - command_line
+      - exe
+      - image_path
+      - md5_hash
+      - pid
+      - ppid
+      - sha1_hash
+      - sha256_hash
+      - user
+      - current_working_directory
+  - object: driver
+    action: load
+    notes: 'Mapped to the drivers and hash tables.'
+    fields:
+      - image_path
+      - md5_hash
+      - module_name
+      - sha1_hash
+      - sha256_hash
+  - object: registry
+    action: edit
+    notes: 'Mapped to the registry table.'
+    fields:
+      - key
+      - type
+      - value
+      - data
+other_coverage:
+  - 'N/A'


### PR DESCRIPTION
This is a minimal osquery sensor model that should cover basic things on Windows, macOS, FreeBSD, and Linux systems.

Where possible, I chose to use eventing tables in osquery. This lets us use audit events coming from the kernel over point-in-time reporting. 

In Windows, we also have the ability to enumerate services, but I chose not to include that here because there wasn't a good way to match them up to the data model for services.