### PR TITLE
CAR-2021-11-002-T1547.004

### DIFF
--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -24,8 +24,6 @@ coverage:
   - technique: T1112
     tactics:
       - TA0005
-    subtechniques:
-      - T1112
     coverage: Medium
 implementations:
   - name: Splunk Search - Modification of Userinit, Shell or BootExecute
@@ -44,12 +42,10 @@ implementations:
       (EventLog="Security" ((((event_id="4688" OR event_id="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((event_id="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
     type: LogPoint
 unit_tests:
-- configurations:
-  description: Modification on Registry Key with cmd. Calc.exe will be launched when user will login
+- description: Modification on Registry Key with cmd. Calc.exe will be launched when user will login
   commands:
   - reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" /v Userinit /d C:\Windows\system32\userinit.exe,C:\Windows\system32\calc.exe
-- configurations:
-  description: Modification on Registry Key with Powershell. Calc.exe will be launched when user will login
+- description: Modification on Registry Key with Powershell. Calc.exe will be launched when user will login
   commands:
   - Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name Userinit -Value C:\Windows\system32\userinit.exe,C:\Windows\system32\calc.exe
 data_model_references:

--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -1,4 +1,4 @@
-title: Registry edit with modification of Userinit, Shell or BootExecute
+title: Registry Edit with Modification of Userinit, Shell or BootExecute
 submission_date: 2021/11/28
 information_domain: Host
 platforms:

--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -12,7 +12,7 @@ contributors:
   - Lucas Heiligenstein
 id: CAR-2021-11-002
 description: |-
-  Detection of modification of registry key Notify,Userinit and Shell located in HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ and HKEY_LOCAL_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\. When user logon, the Registry keys Notify, Userinit and Shell are used to load dedicated Windows component. Attacker may insert malicious payload following the legit value to launch a malicious payload.
+  Detection of modification of the registry key values of `Notify`, `Userinit`, and `Shell` located in `HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\` and `HKEY_LOCAL_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\`. When a user logs on, the Registry key values of `Notify`, `Userinit` and `Shell` are used to load dedicated Windows component. Attackers may insert malicious payload following the legitimate value to launch a malicious payload.
 coverage:
   - technique: T1547
     tactics:

--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -12,7 +12,7 @@ contributors:
   - Lucas Heiligenstein
 id: CAR-2021-11-002
 description: |-
-  Detection of modification of registry key Notify,Userinit and Shell located in HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ and HKEY_LOCAL_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\. When user logon, the Registry keys Notify, Userinit and Shell are used to load deicated Windows component. Attacker may insert malicous payload following the legit value to launch a malicious payload.
+  Detection of modification of registry key Notify,Userinit and Shell located in HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ and HKEY_LOCAL_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\. When user logon, the Registry keys Notify, Userinit and Shell are used to load dedicated Windows component. Attacker may insert malicious payload following the legit value to launch a malicious payload.
 coverage:
   - technique: T1547
     tactics:

--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -1,4 +1,4 @@
-title: Registry Edit with Modification of Userinit, Shell or BootExecute
+title: Registry Edit with Modification of Userinit, Shell or Notify
 submission_date: 2021/11/28
 information_domain: Host
 platforms:
@@ -26,20 +26,20 @@ coverage:
       - TA0005
     coverage: Medium
 implementations:
-  - name: Splunk Search - Modification of Userinit, Shell or BootExecute
+  - name: Splunk Search - Modification of Userinit, Shell or Notify
     description: This is a pseudocode representation of the below Splunk search.
     code: |- 
-      (source="WinEventLog:*" EventLog="Security" ((((EventCode="4688" OR EventCode="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((EventCode="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
+      (source="WinEventLog:*" ((((EventCode="4688" OR EventCode="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR ((CommandLine="*Set-ItemProperty*" OR CommandLine="*New-ItemProperty*") CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*" (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*Notify*")) OR ((EventCode="4657") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="Notify"))) OR ((EventCode="13") (TargetObject="*Userinit" OR TargetObject="*Shell" OR TargetObject="*Notify"))))
     type: Splunk
-  - name: Elastic Search - Modification of Userinit, Shell or BootExecute
+  - name: Elastic Search - Modification of Userinit, Shell or Notify
     description: This is a pseudocode representation of the below Elastic search.
     code: |- 
-      (EventLog:"Security" AND ((((winlog.event_id:"4688" OR winlog.event_id:"1") AND ((process.command_line:*reg* AND process.command_line:*add* AND process.command_line:*\/d*) OR (process.command_line:*Set\-ItemProperty* AND process.command_line:*\-value*)) AND process.command_line:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon*) AND (process.command_line:*Userinit* OR process.command_line:*Shell* OR process.command_line:*BootExecute*)) OR ((winlog.event_id:"4657" AND winlog.event_data.ObjectName:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon*) AND (winlog.event_data.ObjectValueName:"Userinit" OR winlog.event_data.ObjectValueName:"Shell" OR winlog.event_data.ObjectValueName:"BootExecute"))))
+      (((EventCode:("4688" OR "1") AND ((process.command_line:*reg* AND process.command_line:*add* AND process.command_line:*\/d*) OR (process.command_line:(*Set\-ItemProperty* OR *New\-ItemProperty*) AND process.command_line:*\-value*)) AND process.command_line:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon* AND process.command_line:(*Userinit* OR *Shell* OR *Notify*)) OR (EventCode:"4657" AND winlog.event_data.ObjectValueName:("Userinit" OR "Shell" OR "Notify"))) OR (EventCode:"13" AND winlog.event_data.TargetObject:(*Userinit OR *Shell OR *Notify)))
     type: Elastic
-  - name: LogPoint Search - Modification of Userinit, Shell or BootExecute
+  - name: LogPoint Search - Modification of Userinit, Shell or Notify
     description: This is a pseudocode representation of the below LogPoint search.
     code: |- 
-      (EventLog="Security" ((((event_id="4688" OR event_id="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((event_id="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
+      (((EventCode IN ["4688", "1"] ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine IN ["*Set-ItemProperty*", "*New-ItemProperty*"] CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*" CommandLine IN ["*Userinit*", "*Shell*", "*Notify*"]) OR (EventCode IN "4657" ObjectValueName IN ["Userinit", "Shell", "Notify"])) OR (EventCode IN "13" TargetObject IN ["*Userinit", "*Shell", "*Notify"]))
     type: LogPoint
 unit_tests:
 - description: Modification on Registry Key with cmd. Calc.exe will be launched when user will login

--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -12,7 +12,7 @@ contributors:
   - Lucas Heiligenstein
 id: CAR-2021-11-002
 description: |-
-  Detection of modification of registry key Notify,Userinit and Shell located in HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ and HKEY_LOCAL_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\. When user logon, the Registry keys Notify, Userinit and Shell are used to load dedicated Windows component. Attacker may insert malicious payload following the legit value to launch a malicious payload.
+  Detection of modification of registry key Notify,Userinit and Shell located in HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ and HKEY_LOCAL_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\. When user logon, the Registry keys Notify, Userinit and Shell are used to load deicated Windows component. Attacker may insert malicous payload following the legit value to launch a malicious payload.
 coverage:
   - technique: T1547
     tactics:
@@ -31,17 +31,17 @@ implementations:
   - name: Splunk Search - Modification of Userinit, Shell or BootExecute
     description: This is a pseudocode representation of the below Splunk search.
     code: |- 
-      (source="WinEventLog:*" EventLog="Security" (((EventCode="4688" ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((EventCode="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
+      (source="WinEventLog:*" EventLog="Security" ((((EventCode="4688" OR EventCode="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((EventCode="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
     type: Splunk
   - name: Elastic Search - Modification of Userinit, Shell or BootExecute
     description: This is a pseudocode representation of the below Elastic search.
     code: |- 
-      (EventLog:"Security" AND (((winlog.event_id:"4688" AND ((process.command_line:*reg* AND process.command_line:*add* AND process.command_line:*\/d*) OR (process.command_line:*Set\-ItemProperty* AND process.command_line:*\-value*)) AND process.command_line:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon*) AND (process.command_line:*Userinit* OR process.command_line:*Shell* OR process.command_line:*BootExecute*)) OR ((winlog.event_id:"4657" AND winlog.event_data.ObjectName:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon*) AND (winlog.event_data.ObjectValueName:"Userinit" OR winlog.event_data.ObjectValueName:"Shell" OR winlog.event_data.ObjectValueName:"BootExecute"))))
+      (EventLog:"Security" AND ((((winlog.event_id:"4688" OR winlog.event_id:"1") AND ((process.command_line:*reg* AND process.command_line:*add* AND process.command_line:*\/d*) OR (process.command_line:*Set\-ItemProperty* AND process.command_line:*\-value*)) AND process.command_line:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon*) AND (process.command_line:*Userinit* OR process.command_line:*Shell* OR process.command_line:*BootExecute*)) OR ((winlog.event_id:"4657" AND winlog.event_data.ObjectName:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon*) AND (winlog.event_data.ObjectValueName:"Userinit" OR winlog.event_data.ObjectValueName:"Shell" OR winlog.event_data.ObjectValueName:"BootExecute"))))
     type: Elastic
   - name: LogPoint Search - Modification of Userinit, Shell or BootExecute
     description: This is a pseudocode representation of the below LogPoint search.
     code: |- 
-      (EventLog="Security" (((event_id="4688" ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((event_id="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
+      (EventLog="Security" ((((event_id="4688" OR event_id="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((event_id="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
     type: LogPoint
 unit_tests:
 - configurations:

--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -1,0 +1,57 @@
+title: Registry edit with modification of Userinit, Shell or BootExecute
+submission_date: 2021/11/28
+information_domain: Host
+platforms:
+  - Windows
+subtypes:
+  - Process
+  - Registry
+analytic_types:
+  - TTP
+contributors:
+  - Lucas Heiligenstein
+id: CAR-2021-11-002
+description: |-
+  Detection of modification of registry key Notify,Userinit and Shell located in HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ and HKEY_LOCAL_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\. When user logon, the Registry keys Notify, Userinit and Shell are used to load deicated Windows component. Attacker may insert malicous payload following the legit value to launch a malicious payload.
+coverage:
+  - technique: T1547
+    tactics:
+      - TA0003
+      - TA0004
+    subtechniques:
+      - T1547.004
+    coverage: Medium
+  - technique: T1112
+    tactics:
+      - TA0005
+    subtechniques:
+      - T1112
+    coverage: Medium
+implementations:
+  - name: Splunk Search - Modification of Userinit, Shell or BootExecute
+    description: This is a pseudocode representation of the below Splunk search.
+    code: |- 
+      (source="WinEventLog:*" EventLog="Security" (((EventCode="4688" ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((EventCode="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
+    type: Splunk
+  - name: Elastic Search - Modification of Userinit, Shell or BootExecute
+    description: This is a pseudocode representation of the below Elastic search.
+    code: |- 
+      (EventLog:"Security" AND (((winlog.event_id:"4688" AND ((process.command_line:*reg* AND process.command_line:*add* AND process.command_line:*\/d*) OR (process.command_line:*Set\-ItemProperty* AND process.command_line:*\-value*)) AND process.command_line:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon*) AND (process.command_line:*Userinit* OR process.command_line:*Shell* OR process.command_line:*BootExecute*)) OR ((winlog.event_id:"4657" AND winlog.event_data.ObjectName:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon*) AND (winlog.event_data.ObjectValueName:"Userinit" OR winlog.event_data.ObjectValueName:"Shell" OR winlog.event_data.ObjectValueName:"BootExecute"))))
+    type: Elastic
+  - name: LogPoint Search - Modification of Userinit, Shell or BootExecute
+    description: This is a pseudocode representation of the below LogPoint search.
+    code: |- 
+      (EventLog="Security" (((event_id="4688" ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine="*Set-ItemProperty*" CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*BootExecute*")) OR ((event_id="4657" ObjectName="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="BootExecute"))))
+    type: LogPoint
+unit_tests:
+- configurations:
+  description: Modification on Registry Key with cmd. Calc.exe will be launched when user will login
+  commands:
+  - reg add "HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon" /v Userinit /d C:\Windows\system32\userinit.exe,C:\Windows\system32\calc.exe
+- configurations:
+  description: Modification on Registry Key with Powershell. Calc.exe will be launched when user will login
+  commands:
+  - Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -Name Userinit -Value C:\Windows\system32\userinit.exe,C:\Windows\system32\calc.exe
+data_model_references:
+  - process/create/command_line
+  - registry/add/key

--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -26,18 +26,28 @@ coverage:
       - TA0005
     coverage: Medium
 implementations:
+  - name: Userinit/Shell/Notify Registry Modifications
+    description: This detects logon registry key modification, either via a new process (command line) or direct registry manipulation.
+    code: |- 
+      processes = search Process:create
+      logon_reg_processes = filter processes where command_line CONTAINS("*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*") AND (command_line CONTAINS("*Userinit*") OR command_line CONTAINS("*Shell*") OR command_line CONTAINS("*Notify*")) AND (((command_line CONTAINS("*reg*") OR command_line CONTAINS("*add*") OR command_line CONTAINS("*/d*")) OR (command_line CONTAINS("*Set-ItemProperty*") OR command_line CONTAINS("*New-ItemProperty*") OR command_line CONTAINS("*-value*"))))
+      reg_keys = search Registry:value_edit
+      logon_reg_keys = filter reg_keys where (value="Userinit" OR value="Shell" OR value="Notify")
+      output logon_reg_processes, logon_reg_keys
+    data_model: CAR native
+    type: Pseudocode
   - name: Splunk Search - Modification of Userinit, Shell or Notify
-    description: This is a pseudocode representation of the below Splunk search.
+    description: This is a Splunk representation of the above pseudocode.
     code: |- 
       (((((EventCode="4688" OR EventCode="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR ((CommandLine="*Set-ItemProperty*" OR CommandLine="*New-ItemProperty*") CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*" (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*Notify*")) OR ((EventCode="4657") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="Notify"))) OR ((EventCode="13") (TargetObject="*Userinit" OR TargetObject="*Shell" OR TargetObject="*Notify"))))
     type: Splunk
   - name: Elastic Search - Modification of Userinit, Shell or Notify
-    description: This is a pseudocode representation of the below Elastic search.
+    description: This is an ElasticSearch representation of the above pseudocode.
     code: |- 
       (((EventCode:("4688" OR "1") AND ((process.command_line:*reg* AND process.command_line:*add* AND process.command_line:*\/d*) OR (process.command_line:(*Set\-ItemProperty* OR *New\-ItemProperty*) AND process.command_line:*\-value*)) AND process.command_line:*\\Microsoft\\Windows\ NT\\CurrentVersion\\Winlogon* AND process.command_line:(*Userinit* OR *Shell* OR *Notify*)) OR (EventCode:"4657" AND winlog.event_data.ObjectValueName:("Userinit" OR "Shell" OR "Notify"))) OR (EventCode:"13" AND winlog.event_data.TargetObject:(*Userinit OR *Shell OR *Notify)))
     type: Elastic
   - name: LogPoint Search - Modification of Userinit, Shell or Notify
-    description: This is a pseudocode representation of the below LogPoint search.
+    description: This is a LogPoint representation of the above pseudocode.
     code: |- 
       (((EventCode IN ["4688", "1"] ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR (CommandLine IN ["*Set-ItemProperty*", "*New-ItemProperty*"] CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*" CommandLine IN ["*Userinit*", "*Shell*", "*Notify*"]) OR (EventCode IN "4657" ObjectValueName IN ["Userinit", "Shell", "Notify"])) OR (EventCode IN "13" TargetObject IN ["*Userinit", "*Shell", "*Notify"]))
     type: LogPoint

--- a/analytics/CAR-2021-11-002.yaml
+++ b/analytics/CAR-2021-11-002.yaml
@@ -29,7 +29,7 @@ implementations:
   - name: Splunk Search - Modification of Userinit, Shell or Notify
     description: This is a pseudocode representation of the below Splunk search.
     code: |- 
-      (source="WinEventLog:*" ((((EventCode="4688" OR EventCode="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR ((CommandLine="*Set-ItemProperty*" OR CommandLine="*New-ItemProperty*") CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*" (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*Notify*")) OR ((EventCode="4657") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="Notify"))) OR ((EventCode="13") (TargetObject="*Userinit" OR TargetObject="*Shell" OR TargetObject="*Notify"))))
+      (((((EventCode="4688" OR EventCode="1") ((CommandLine="*reg*" CommandLine="*add*" CommandLine="*/d*") OR ((CommandLine="*Set-ItemProperty*" OR CommandLine="*New-ItemProperty*") CommandLine="*-value*")) CommandLine="*\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon*" (CommandLine="*Userinit*" OR CommandLine="*Shell*" OR CommandLine="*Notify*")) OR ((EventCode="4657") (ObjectValueName="Userinit" OR ObjectValueName="Shell" OR ObjectValueName="Notify"))) OR ((EventCode="13") (TargetObject="*Userinit" OR TargetObject="*Shell" OR TargetObject="*Notify"))))
     type: Splunk
   - name: Elastic Search - Modification of Userinit, Shell or Notify
     description: This is a pseudocode representation of the below Elastic search.


### PR DESCRIPTION
-Finished-
Detection of modification of registry key Notify,Userinit and Shell located in HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\ and HKEY_LOCAL_USER\Software\Microsoft\Windows NT\CurrentVersion\Winlogon\. When user logon, the Registry keys Notify, Userinit and Shell are used to load dedicated Windows component. Attacker may insert malicious payload following the legit value to launch a malicious payload.