### PR TITLE
ADD : %windir% in CAR-2021-05-012.yaml

### DIFF
--- a/analytics/CAR-2021-05-012.yaml
+++ b/analytics/CAR-2021-05-012.yaml
@@ -28,7 +28,7 @@ implementations:
   description: Pseudocode implementation of the Splunk search below. 
   code: |- 
       services = search Service:create
-      suspicious_services = filter services where image_path = "*\.exe" AND image_path does not contain ["C:\\Windows\\*", "C:\\Program File*", "C:\\Programdata\\*", "%systemroot%\\*"] )
+      suspicious_services = filter services where image_path = "*\.exe" AND image_path does not contain ["C:\\Windows\\*", "%windir%\\*", "C:\\Program File*", "C:\\Programdata\\*", "%systemroot%\\*"] )
       output suspicious_services
   data_model: CAR native
   type: Pseudocode
@@ -37,7 +37,7 @@ implementations:
     with the Service name, Service File Name Service Start type, and Service Type
     from your endpoints.
   code: ' `wineventlog_system` EventCode=7045  Service_File_Name = "*\.exe" NOT (Service_File_Name
-    IN ("C:\\Windows\\*", "C:\\Program File*", "C:\\Programdata\\*", "%systemroot%\\*"))
+    IN ("C:\\Windows\\*", "%windir%\\*", "C:\\Program File*", "C:\\Programdata\\*", "%systemroot%\\*"))
     Service_Type = "user mode service" | stats count min(_time) as firstTime max(_time)
     as lastTime by EventCode Service_File_Name Service_Name Service_Start_Type Service_Type'
   type: Splunk


### PR DESCRIPTION
I used this rule with the EventID 4697 and had cases where the service file path was starting with "%windir%\" which equals to "C:\Windows\" if Windows is installed on C:.

I didn't check if EventID 7045 translates "%windir%" to "C:\Windows", but I don't think so as %systemroot% is not translated in the event.